### PR TITLE
Fix: Set python script as entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ COPY credentials .
 
 WORKDIR /root
 
-CMD ["/app/aws-sso.py"]
-
+ENTRYPOINT ["/app/aws-sso.py"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 ## Assume role in AWS using ASU Single Sign-On
 
-#### Usage:
+### Usage:
 
+#### Method 1 (standard).
 `docker run -it --rm -v ~/.aws:/root/.aws asuuto/aws-sso:latest`
 
 (or `-v %userprofile%\.aws:/root/.aws` when running on Windows)
 
-then you can, for example
+#### Method 2 (using optional args).
+`docker run -it --rm -v ~/.aws:/root/.aws asuuto/aws-sso:latest <username> <password> <duration> <organization>`
+
+(or `-v %userprofile%\.aws:/root/.aws` when running on Windows)
+
+When using this method, all four of the following must be defined:
+
+- `username` : the SSO user intended to assume the role.
+- `password` : the password of the SSO user intended to assume the role.
+  - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file`.
+- `duration` : length of time that the SSO user will have the role (in seconds).
+  - This value must be less than or equal to the maximum session duration of the assumed role.
+- `organization` : use 'production'.
+
+If either of the above methods completed successfully, you should be able to run commands using AWS CLI.
+
+Example:
 
 `aws --profile saml s3 ls`
 
-or, if you don't have the aws cli installed locally
+or, if you don't have the aws cli installed locally:
 
 `docker run -it --rm -v ~/.aws:/root/.aws asuuto/awscli:latest aws --profile saml s3 ls`
 
-if you don't already have a `~/.aws/credentials` file, start with this one
+---
+
+If you don't already have a `~/.aws/credentials` file, start with this one
 
 ```
 [default]
@@ -24,18 +43,19 @@ aws_access_key_id =
 aws_secret_access_key = 
 ```
 
-#### Side Effects:
+### Side Effects:
 
 * Creates/updates a `saml` profile in `~/.aws/credentials`
 * Creates/updates `~/.aws/sso_session_cookies` to cache your ASU SSO and MFA sessions
 
-#### Build:
+### Build:
 
 ```
 docker build --pull -t asuuto/aws-sso:latest .
 docker push asuuto/aws-sso:latest
 ```
 
-#### Known issues:
+### Known issues:
 - An error may be thrown if you have access to only one AWS account/role
 - Process fails if you are being prompted to change your password at login
+- A validation error will occur if the duration is greater than the `MaxSessionDuration`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When using this method, all four of the following must be defined:
 
 - `username` : the SSO user intended to assume the role.
 - `password` : the password of the SSO user intended to assume the role.
-  - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file`.
+  - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file)`.
 - `duration` : length of time that the SSO user will have the role (in seconds).
   - This value must be less than or equal to the maximum session duration of the assumed role.
 - `organization` : use 'production'.


### PR DESCRIPTION
Stop-gap solution.

- Set Python script as entrypoint to allow setting of script args via strings at the end of `docker run` command.
- Update README.md.