### PR TITLE
Set token duration equal to payload duration

### DIFF
--- a/aws-sso.py
+++ b/aws-sso.py
@@ -398,7 +398,7 @@ with open(cookiefile, 'wb') as f:
 
 # Use the assertion to get an AWS STS token using Assume Role with SAML
 conn = boto.sts.connect_to_region(region)
-token = conn.assume_role_with_saml(role_arn, principal_arn, assertion, duration_seconds=32400)
+token = conn.assume_role_with_saml(role_arn, principal_arn, assertion, duration_seconds=duration)
 
 # Write the AWS STS token into the AWS credential file
 home = expanduser("~")


### PR DESCRIPTION
The default of `32400` needs to be overridden because not all roles to be assumed have a `MaxSessionDuration` that is less than or equal to that value.