### PR TITLE
Fix/separate duration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When using this method, all four of the following must be defined:
 - `username` : the SSO user intended to assume the role.
 - `password` : the password of the SSO user intended to assume the role.
   - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file)`.
-- `sso_duration` : duration of the SSO user's session (default: 30 [units unknown])
+- `sso_duration` : duration of the SSO user's session (default: 30, units unknown)
   - This may be the length of time the user's login credentials will last with the script before a new login is required, but this is somewhat uncertain.
 - `assume_role_duration`: length of time that the SSO user will have the role (in seconds).
   - This value must be less than or equal to the maximum session duration of the assumed role.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 (or `-v %userprofile%\.aws:/root/.aws` when running on Windows)
 
 #### Method 2 (using optional args).
-`docker run -it --rm -v ~/.aws:/root/.aws asuuto/aws-sso:latest <username> <password> <duration> <organization>`
+`docker run -it --rm -v ~/.aws:/root/.aws asuuto/aws-sso:latest <username> <password> <sso_duration> <assume_role_duration> <organization>`
 
 (or `-v %userprofile%\.aws:/root/.aws` when running on Windows)
 
@@ -17,7 +17,9 @@ When using this method, all four of the following must be defined:
 - `username` : the SSO user intended to assume the role.
 - `password` : the password of the SSO user intended to assume the role.
   - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file)`.
-- `duration` : length of time that the SSO user will have the role (in seconds).
+- `sso_duration` : duration of the SSO user's session (units unknown).
+  - This may be the length of time the user's login credentials will last with the script before a new login is required, but this is somewhat uncertain.
+- `assume_role_duration`: length of time that the SSO user will have the role (in seconds).
   - This value must be less than or equal to the maximum session duration of the assumed role.
 - `organization` : use 'production'.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 (or `-v %userprofile%\.aws:/root/.aws` when running on Windows)
 
-When using this method, all four of the following must be defined:
+When using this method, all five of the following must be defined:
 
 - `username` : the SSO user intended to assume the role.
 - `password` : the password of the SSO user intended to assume the role.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When using this method, all four of the following must be defined:
 - `username` : the SSO user intended to assume the role.
 - `password` : the password of the SSO user intended to assume the role.
   - It is recommended that this be sourced from a file or environment variable (IE: `$(cat /path/to/password/file)`.
-- `sso_duration` : duration of the SSO user's session (units unknown).
+- `sso_duration` : duration of the SSO user's session (default: 30 [units unknown])
   - This may be the length of time the user's login credentials will last with the script before a new login is required, but this is somewhat uncertain.
 - `assume_role_duration`: length of time that the SSO user will have the role (in seconds).
   - This value must be less than or equal to the maximum session duration of the assumed role.

--- a/aws-sso.py
+++ b/aws-sso.py
@@ -64,6 +64,8 @@ session = requests.Session()
 # If there is no cached login, or it's expired, go through the login process again
 need_login = True
 assertion = ''
+sso_duration = 30
+assume_role_duration = 32400
 
 if isfile(cookiefile):
     with open(cookiefile, 'rb') as f:
@@ -86,14 +88,14 @@ if need_login:
     if len(sys.argv) > 4:
         username = sys.argv[1]
         password = sys.argv[2]
-        duration = sys.argv[3]
-        organization = sys.argv[4]
+        sso_duration = sys.argv[3]
+        assume_role_duration = sys.argv[4]
+        organization = sys.argv[5]
     else:
         print "ASURITE Username:",
         username = raw_input()
         password = getpass.getpass()
         print ''
-        duration = 30
         organization = 'production'
 
     # Programmatically get the SAML assertion
@@ -131,7 +133,7 @@ if need_login:
     #payload['_eventId_proceed'] = ''
 
     # Populate the following from input or defaults 
-    payload['session-duration'] = duration
+    payload['session-duration'] = sso_duration
     payload['organization'] = organization
 
     # Debug the parameter payload if needed
@@ -398,7 +400,7 @@ with open(cookiefile, 'wb') as f:
 
 # Use the assertion to get an AWS STS token using Assume Role with SAML
 conn = boto.sts.connect_to_region(region)
-token = conn.assume_role_with_saml(role_arn, principal_arn, assertion, duration_seconds=32400)
+token = conn.assume_role_with_saml(role_arn, principal_arn, assertion, duration_seconds=assume_role_duration)
 
 # Write the AWS STS token into the AWS credential file
 home = expanduser("~")
@@ -441,4 +443,3 @@ buckets = s3conn.get_all_buckets()
 
 print 'Simple API example listing all S3 buckets:'
 print(buckets)
-

--- a/aws-sso.py
+++ b/aws-sso.py
@@ -85,7 +85,7 @@ if isfile(cookiefile):
 
 if need_login:
     # Get the federated credentials from the user
-    if len(sys.argv) > 4:
+    if len(sys.argv) > 5:
         username = sys.argv[1]
         password = sys.argv[2]
         sso_duration = sys.argv[3]


### PR DESCRIPTION
A try with two separate duration parameters, one for the request involving ASU SSO or Duo and the other for the assume role call for AWS, since the values seemed quite different and might be in different time units. Updated the README with the new usage, but I was uncertain what the sso_duration parameter is for, so it sounds confusing.